### PR TITLE
Tweaked live editing sign out button to work in newer browsers

### DIFF
--- a/iu-resources/js/instant.js
+++ b/iu-resources/js/instant.js
@@ -18,7 +18,7 @@ $iu$(document).ready(function() {
 		menu_items.push({'class': 'iu-icon-source', 'href': IU_SITE_URL+'/administration/templates/edit/'+$iu$.trim($iu$('body').data('template')), 'content': 'Edit Source'});
 
 
-		menu_items.push({'class': 'iu-icon-signout', 'href': 'javascript:void(0);', 'content': 'Sign Out ('+IU_USER.name+')', onClick:function($li,num){ location.href=IU_SITE_URL+'/administration/auth/logout'; } });
+		menu_items.push({'class': 'iu-icon-signout', 'href': 'javascript:window.location.href=\''+ IU_SITE_URL + '/administration/auth/logout\';', 'content': 'Sign Out (' + IU_USER.name + ')'});
 
 
 	icoroll({


### PR DESCRIPTION
The sign out button was not working when live editing in newer browsers.

Didn't work with Brave: 0.11.5 and Google Chrome 54.0.2840.71 (Official Build) (64-bit). It was working with Firefox 49.0 though. 

I updated iu-resources/js/instant.js to have the live editing sign out button work in all of the above browsers.  